### PR TITLE
Remove unused CoreWars using statement.

### DIFF
--- a/BlockType.cs
+++ b/BlockType.cs
@@ -1,4 +1,3 @@
-﻿using Facepunch.CoreWars;
 using Sandbox;
 
 namespace Facepunch.Voxels


### PR DESCRIPTION
Removed a using statement that throws errors when using sbox-voxels as a submodule outside of the CoreWars project.